### PR TITLE
Fix chinook test and CI improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+# Force bash shell (required when make is invoked from PowerShell/cmd.exe)
+# Use 8.3 short path to avoid spaces in "Program Files"
+ifneq ($(OS),Windows_NT)
+  SHELL := /bin/bash
+else
+  SHELL := C:/PROGRA~1/Git/bin/bash.exe
+endif
+.SHELLFLAGS := -c
+
 .PHONY: test test-acc test-acc-ci test-consistency test-conversation-model \
 	start-typesense stop-typesense build clean wsl-keepalive \
 	testbed-up testbed-down testbed-seed testbed-e2e testbed-verify testbed-clean \


### PR DESCRIPTION
## Summary
- Fix Makefile to work from PowerShell by setting explicit `SHELL` to bash
- Add chinook acceptance test job to CI workflow
- Fix collection field `async_reference` type and `hnsw_params` computed attributes
- Fix stemming dictionary, synonym set, and other resource issues for Typesense v30.1
- Fix lint and unit test failures

## Test plan
- [x] `make -n chinook-test` dry-run succeeds from PowerShell (new make 4.4.1)
- [x] `make -n chinook-test` dry-run succeeds from Git Bash
- [x] CI workflow includes chinook acceptance test job