### PR TITLE
feat(api-key): support user-provided key values, value_prefix, and autodelete

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,11 +372,37 @@ resource "typesense_stopwords_set" "english" {
   stopwords = ["the", "a", "an", "and", "or", "but"]
 }
 
-# 4. Create search-only API key
+# 4. Create search-only API key (auto-generated value)
 resource "typesense_api_key" "public_search" {
   description = "Public search key"
   actions     = ["documents:search"]
   collections = [typesense_collection.articles.name]
+}
+
+# 5. Create a key with a specific value (same across prod/staging)
+resource "typesense_api_key" "shared_search" {
+  description = "Shared search key"
+  value       = var.shared_search_key
+  actions     = ["documents:search"]
+  collections = ["*"]
+}
+
+# 6. Create a temporary key that auto-deletes after expiration
+resource "typesense_api_key" "temp_key" {
+  description = "Temporary ingest key"
+  actions     = ["documents:create"]
+  collections = ["*"]
+  expires_at  = 1735689600
+  autodelete  = true
+}
+
+output "search_api_key" {
+  value     = typesense_api_key.public_search.value
+  sensitive = true
+}
+
+output "search_key_prefix" {
+  value = typesense_api_key.public_search.value_prefix
 }
 ```
 

--- a/examples/chinook/api_keys.tf
+++ b/examples/chinook/api_keys.tf
@@ -46,3 +46,20 @@ resource "typesense_api_key" "analytics_reader" {
     typesense_collection.nohits_queries.name,
   ]
 }
+
+# Shared search key with user-provided value
+# Demonstrates multi-environment pattern: use the same key value across
+# prod/staging by passing it as a variable, so client applications don't
+# need to update their key when switching environments.
+resource "typesense_api_key" "shared_search" {
+  count = var.shared_search_key != "" ? 1 : 0
+
+  description = "Shared search key (same value across environments)"
+  value       = var.shared_search_key
+  actions     = ["documents:search"]
+  collections = [
+    typesense_collection.tracks.name,
+    typesense_collection.albums.name,
+    typesense_collection.artists.name,
+  ]
+}

--- a/examples/chinook/outputs.tf
+++ b/examples/chinook/outputs.tf
@@ -294,22 +294,25 @@ output "api_keys" {
   description = "API keys configured for different access levels"
   value = {
     search_only = {
-      id          = typesense_api_key.search_only.id
-      description = typesense_api_key.search_only.description
-      collections = typesense_api_key.search_only.collections
-      actions     = typesense_api_key.search_only.actions
+      id           = typesense_api_key.search_only.id
+      description  = typesense_api_key.search_only.description
+      value_prefix = typesense_api_key.search_only.value_prefix
+      collections  = typesense_api_key.search_only.collections
+      actions      = typesense_api_key.search_only.actions
     }
     customer_admin = {
-      id          = typesense_api_key.customer_admin.id
-      description = typesense_api_key.customer_admin.description
-      collections = typesense_api_key.customer_admin.collections
-      actions     = typesense_api_key.customer_admin.actions
+      id           = typesense_api_key.customer_admin.id
+      description  = typesense_api_key.customer_admin.description
+      value_prefix = typesense_api_key.customer_admin.value_prefix
+      collections  = typesense_api_key.customer_admin.collections
+      actions      = typesense_api_key.customer_admin.actions
     }
     analytics_reader = {
-      id          = typesense_api_key.analytics_reader.id
-      description = typesense_api_key.analytics_reader.description
-      collections = typesense_api_key.analytics_reader.collections
-      actions     = typesense_api_key.analytics_reader.actions
+      id           = typesense_api_key.analytics_reader.id
+      description  = typesense_api_key.analytics_reader.description
+      value_prefix = typesense_api_key.analytics_reader.value_prefix
+      collections  = typesense_api_key.analytics_reader.collections
+      actions      = typesense_api_key.analytics_reader.actions
     }
   }
 }
@@ -318,4 +321,12 @@ output "search_api_key_value" {
   description = "Search-only API key value (for client-side use)"
   value       = typesense_api_key.search_only.value
   sensitive   = true
+}
+
+output "shared_search_key" {
+  description = "Shared search key details (only present when shared_search_key variable is set)"
+  value = length(typesense_api_key.shared_search) > 0 ? {
+    id           = typesense_api_key.shared_search[0].id
+    value_prefix = typesense_api_key.shared_search[0].value_prefix
+  } : null
 }

--- a/examples/chinook/variables.tf
+++ b/examples/chinook/variables.tf
@@ -43,3 +43,11 @@ variable "conversation_model_name" {
   description = "LLM model to use for conversational search (RAG)"
   default     = "openai/gpt-4o-mini"
 }
+
+# Multi-environment API key
+variable "shared_search_key" {
+  type        = string
+  description = "User-provided search key value for consistent keys across environments (optional)"
+  sensitive   = true
+  default     = ""
+}

--- a/internal/client/server_client.go
+++ b/internal/client/server_client.go
@@ -203,6 +203,7 @@ type APIKey struct {
 	Actions     []string `json:"actions"`
 	Collections []string `json:"collections"`
 	ExpiresAt   int64    `json:"expires_at,omitempty"`
+	AutoDelete  bool     `json:"autodelete,omitempty"`
 }
 
 // CollectionAlias represents a Typesense collection alias

--- a/internal/resources/api_key_test.go
+++ b/internal/resources/api_key_test.go
@@ -1,6 +1,7 @@
 package resources_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/alanm/terraform-provider-typesense/internal/provider"
@@ -20,6 +21,7 @@ func TestAccAPIKeyResource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("typesense_api_key.test", "id"),
 					resource.TestCheckResourceAttrSet("typesense_api_key.test", "value"),
+					resource.TestCheckResourceAttrSet("typesense_api_key.test", "value_prefix"),
 					resource.TestCheckResourceAttr("typesense_api_key.test", "actions.#", "1"),
 					resource.TestCheckResourceAttr("typesense_api_key.test", "actions.0", "documents:search"),
 					resource.TestCheckResourceAttr("typesense_api_key.test", "collections.#", "1"),
@@ -30,7 +32,7 @@ func TestAccAPIKeyResource_basic(t *testing.T) {
 				ResourceName:            "typesense_api_key.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"value"},
+				ImportStateVerifyIgnore: []string{"value", "autodelete"},
 			},
 		},
 	})
@@ -48,6 +50,7 @@ func TestAccAPIKeyResource_full(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("typesense_api_key.test", "id"),
 					resource.TestCheckResourceAttrSet("typesense_api_key.test", "value"),
+					resource.TestCheckResourceAttrSet("typesense_api_key.test", "value_prefix"),
 					resource.TestCheckResourceAttr("typesense_api_key.test", "description", "Test API key"),
 					resource.TestCheckResourceAttr("typesense_api_key.test", "actions.#", "2"),
 					resource.TestCheckResourceAttr("typesense_api_key.test", "actions.0", "documents:search"),
@@ -61,7 +64,68 @@ func TestAccAPIKeyResource_full(t *testing.T) {
 				ResourceName:            "typesense_api_key.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"value"},
+				ImportStateVerifyIgnore: []string{"value", "autodelete"},
+			},
+		},
+	})
+}
+
+func TestAccAPIKeyResource_userProvidedValue(t *testing.T) {
+	// Bug: user-provided key values weren't supported, making multi-env deployments painful
+	rName := acctest.RandomWithPrefix("test-api-key")
+	keyValue := acctest.RandString(32)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { provider.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIKeyResourceConfig_userProvidedValue(rName, keyValue),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("typesense_api_key.test", "id"),
+					resource.TestCheckResourceAttr("typesense_api_key.test", "value", keyValue),
+					resource.TestCheckResourceAttr("typesense_api_key.test", "value_prefix", keyValue[:4]),
+					resource.TestCheckResourceAttr("typesense_api_key.test", "description", "User-provided value test"),
+					resource.TestCheckResourceAttr("typesense_api_key.test", "actions.#", "1"),
+					resource.TestCheckResourceAttr("typesense_api_key.test", "actions.0", "documents:search"),
+					resource.TestCheckResourceAttr("typesense_api_key.test", "collections.#", "1"),
+					resource.TestCheckResourceAttr("typesense_api_key.test", "collections.0", "*"),
+				),
+			},
+			{
+				ResourceName:            "typesense_api_key.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value", "autodelete"},
+			},
+		},
+	})
+}
+
+func TestAccAPIKeyResource_autodelete(t *testing.T) {
+	// Verify autodelete flag is sent correctly with expires_at
+	rName := acctest.RandomWithPrefix("test-api-key")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { provider.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIKeyResourceConfig_autodelete(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("typesense_api_key.test", "id"),
+					resource.TestCheckResourceAttrSet("typesense_api_key.test", "value"),
+					resource.TestCheckResourceAttrSet("typesense_api_key.test", "value_prefix"),
+					resource.TestCheckResourceAttr("typesense_api_key.test", "description", "Autodelete test key"),
+					resource.TestCheckResourceAttr("typesense_api_key.test", "autodelete", "true"),
+					resource.TestCheckResourceAttrSet("typesense_api_key.test", "expires_at"),
+				),
+			},
+			{
+				ResourceName:            "typesense_api_key.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value", "autodelete"},
 			},
 		},
 	})
@@ -83,6 +147,29 @@ resource "typesense_api_key" "test" {
   actions     = ["documents:search", "documents:get"]
   collections = ["*"]
   expires_at  = 9999999999
+}
+`
+}
+
+func testAccAPIKeyResourceConfig_userProvidedValue(_ string, value string) string {
+	return fmt.Sprintf(`
+resource "typesense_api_key" "test" {
+  description = "User-provided value test"
+  value       = %q
+  actions     = ["documents:search"]
+  collections = ["*"]
+}
+`, value)
+}
+
+func testAccAPIKeyResourceConfig_autodelete(_ string) string {
+	return `
+resource "typesense_api_key" "test" {
+  description = "Autodelete test key"
+  actions     = ["documents:search"]
+  collections = ["*"]
+  expires_at  = 9999999999
+  autodelete  = true
 }
 `
 }


### PR DESCRIPTION
## Summary

- Add `value` attribute (Optional+Computed+Sensitive) to `typesense_api_key` resource, allowing users to specify a custom API key value for consistent keys across multiple environments (prod/staging)
- Add `value_prefix` computed attribute showing the first 4 characters of the key, useful for identifying keys after creation (since GET only returns the prefix)
- Add `autodelete` boolean attribute for automatic key cleanup after expiration

## Changes

**Client** (`internal/client/server_client.go`):
- Add `AutoDelete bool` field to `APIKey` struct

**Resource** (`internal/resources/api_key.go`):
- `value`: Changed from `Computed` to `Optional+Computed+Sensitive` with `UseStateForUnknown()` + `RequiresReplace()` plan modifiers
- `value_prefix`: New `Computed` string attribute with `UseStateForUnknown()`
- `autodelete`: New `Optional` bool attribute with `RequiresReplace()`
- Create: sends user-provided `value` and `autodelete` to API, computes `value_prefix`
- Read: populates `value_prefix` from API response; `value` and `autodelete` preserved from state

**Tests** (`internal/resources/api_key_test.go`):
- `TestAccAPIKeyResource_userProvidedValue`: verifies exact value round-trips and value_prefix computation
- `TestAccAPIKeyResource_autodelete`: verifies autodelete flag with expires_at
- Updated existing tests to check `value_prefix` is set and include `autodelete` in `ImportStateVerifyIgnore`

**Chinook example**:
- Added conditional `shared_search` key demonstrating user-provided value pattern
- Added `shared_search_key` variable (sensitive, default `""`)
- Added `value_prefix` to existing key outputs

**README**: Documented `value`, `value_prefix`, and `autodelete` with usage examples

## Test plan

- [x] `go build` succeeds
- [x] `chinook-apply` creates all 67 resources successfully with `value_prefix` in outputs
- [ ] `make chinook-test` full cycle (manual verification done with apply)
- [ ] Run `TestAccAPIKeyResource_userProvidedValue` against live Typesense
- [ ] Run `TestAccAPIKeyResource_autodelete` against live Typesense