### PR TITLE
fix: harden generated Terraform schema contracts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -1,0 +1,44 @@
+name: Nightly Generate Import Plan
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  nightly-e2e:
+    name: Seeded Generate Import Plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Show tool versions
+        run: |
+          go version
+          terraform version
+          docker --version
+          docker compose version
+          jq --version
+
+      - name: Run seeded generate/import/plan E2E
+        env:
+          CLEANUP_ON_EXIT: "true"
+          FAIL_ON_PLAN_CHANGES: "true"
+        run: ./testbed/scripts/run-e2e-test.sh

--- a/internal/datasources/api_keys.go
+++ b/internal/datasources/api_keys.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -30,7 +31,7 @@ type APIKeysDataSourceModel struct {
 }
 
 func (d *APIKeysDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_api_keys"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.DataSourceAPIKeys)
 }
 
 func (d *APIKeysDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/datasources/collections.go
+++ b/internal/datasources/collections.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -30,7 +31,7 @@ type CollectionsDataSourceModel struct {
 }
 
 func (d *CollectionsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_collections"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.DataSourceCollections)
 }
 
 func (d *CollectionsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/datasources/server_info.go
+++ b/internal/datasources/server_info.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -30,7 +31,7 @@ type ServerInfoDataSourceModel struct {
 }
 
 func (d *ServerInfoDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_server_info"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.DataSourceServerInfo)
 }
 
 func (d *ServerInfoDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	"github.com/alanm/terraform-provider-typesense/internal/version"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
@@ -104,7 +105,7 @@ func (g *Generator) Generate(ctx context.Context) error {
 	generateTerraformBlock(f)
 
 	// Generate provider block
-	generateProviderBlock(f, g.config.Host, g.config.Port, g.config.Protocol)
+	generateProviderBlock(f, g.config.Host, g.config.Port, g.config.Protocol, g.serverClient != nil, g.cloudClient != nil)
 
 	// Track resource names for uniqueness
 	resourceNames := make(map[string]bool)
@@ -201,7 +202,7 @@ func (g *Generator) generateClusters(ctx context.Context, f *hclwrite.File, reso
 		f.Body().AppendNewline()
 
 		*importCommands = append(*importCommands, ImportCommand{
-			ResourceType: "typesense_cluster",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceCluster),
 			ResourceName: resourceName,
 			ImportID:     ClusterImportID(cluster.ID),
 		})
@@ -234,7 +235,7 @@ func (g *Generator) generateCollections(ctx context.Context, f *hclwrite.File, r
 		f.Body().AppendNewline()
 
 		*importCommands = append(*importCommands, ImportCommand{
-			ResourceType: "typesense_collection",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceCollection),
 			ResourceName: resourceName,
 			ImportID:     CollectionImportID(collection.Name),
 		})
@@ -291,7 +292,7 @@ func (g *Generator) generateStopwords(ctx context.Context, f *hclwrite.File, res
 		f.Body().AppendNewline()
 
 		*importCommands = append(*importCommands, ImportCommand{
-			ResourceType: "typesense_stopwords",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceStopwordsSet),
 			ResourceName: resourceName,
 			ImportID:     StopwordsImportID(sw.ID),
 		})
@@ -399,7 +400,7 @@ func (g *Generator) generatePerCollectionSynonyms(ctx context.Context, f *hclwri
 		f.Body().AppendNewline()
 
 		*importCommands = append(*importCommands, ImportCommand{
-			ResourceType: "typesense_synonym",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceSynonym),
 			ResourceName: resourceName,
 			ImportID:     SynonymImportID(item.collectionName, item.synonym.ID),
 		})
@@ -532,7 +533,7 @@ func (g *Generator) generatePerCollectionOverrides(ctx context.Context, f *hclwr
 		f.Body().AppendNewline()
 
 		*importCommands = append(*importCommands, ImportCommand{
-			ResourceType: "typesense_override",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceOverride),
 			ResourceName: resourceName,
 			ImportID:     OverrideImportID(item.collectionName, item.override.ID),
 		})
@@ -588,7 +589,7 @@ func (g *Generator) generateAnalyticsRules(ctx context.Context, f *hclwrite.File
 		f.Body().AppendNewline()
 
 		*importCommands = append(*importCommands, ImportCommand{
-			ResourceType: "typesense_analytics_rule",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceAnalyticsRule),
 			ResourceName: resourceName,
 			ImportID:     AnalyticsRuleImportID(rule.Name),
 		})
@@ -622,7 +623,7 @@ func (g *Generator) generateAPIKeys(ctx context.Context, f *hclwrite.File, resou
 		f.Body().AppendNewline()
 
 		*importCommands = append(*importCommands, ImportCommand{
-			ResourceType: "typesense_api_key",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceAPIKey),
 			ResourceName: resourceName,
 			ImportID:     APIKeyImportID(key.ID),
 		})
@@ -654,7 +655,7 @@ func (g *Generator) generateNLSearchModels(ctx context.Context, f *hclwrite.File
 		f.Body().AppendNewline()
 
 		*importCommands = append(*importCommands, ImportCommand{
-			ResourceType: "typesense_nl_search_model",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceNLSearchModel),
 			ResourceName: resourceName,
 			ImportID:     NLSearchModelImportID(model.ID),
 		})
@@ -686,7 +687,7 @@ func (g *Generator) generateConversationModels(ctx context.Context, f *hclwrite.
 		f.Body().AppendNewline()
 
 		*importCommands = append(*importCommands, ImportCommand{
-			ResourceType: "typesense_conversation_model",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceConversationModel),
 			ResourceName: resourceName,
 			ImportID:     ConversationModelImportID(model.ID),
 		})
@@ -694,4 +695,3 @@ func (g *Generator) generateConversationModels(ctx context.Context, f *hclwrite.
 
 	return nil
 }
-

--- a/internal/generator/hcl.go
+++ b/internal/generator/hcl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -14,27 +15,33 @@ func generateTerraformBlock(f *hclwrite.File) {
 	tfBlock := f.Body().AppendNewBlock("terraform", nil)
 	reqProviders := tfBlock.Body().AppendNewBlock("required_providers", nil)
 	reqProviders.Body().SetAttributeValue("typesense", cty.ObjectVal(map[string]cty.Value{
-		"source": cty.StringVal("alanm/typesense"),
+		"source": cty.StringVal(tfnames.ProviderSource),
 	}))
 	f.Body().AppendNewline()
 }
 
 // generateProviderBlock creates the provider configuration block
-func generateProviderBlock(f *hclwrite.File, host string, port int, protocol string) {
+func generateProviderBlock(f *hclwrite.File, host string, port int, protocol string, includeServerAPIKey bool, includeCloudAPIKey bool) {
 	providerBlock := f.Body().AppendNewBlock("provider", []string{"typesense"})
 	providerBlock.Body().SetAttributeValue("server_host", cty.StringVal(host))
 	providerBlock.Body().SetAttributeValue("server_port", cty.NumberIntVal(int64(port)))
 	providerBlock.Body().SetAttributeValue("server_protocol", cty.StringVal(protocol))
-	// Add comment for API key
-	providerBlock.Body().AppendUnstructuredTokens(hclwrite.Tokens{
-		{Type: 4, Bytes: []byte("# server_api_key = \"YOUR_API_KEY_HERE\"\n")}, // TokenComment = 4
-	})
+	if includeServerAPIKey {
+		providerBlock.Body().AppendUnstructuredTokens(hclwrite.Tokens{
+			{Type: 4, Bytes: []byte("# server_api_key = \"YOUR_API_KEY_HERE\"\n")}, // TokenComment = 4
+		})
+	}
+	if includeCloudAPIKey {
+		providerBlock.Body().AppendUnstructuredTokens(hclwrite.Tokens{
+			{Type: 4, Bytes: []byte("# cloud_management_api_key = \"YOUR_CLOUD_API_KEY_HERE\"\n")}, // TokenComment = 4
+		})
+	}
 	f.Body().AppendNewline()
 }
 
 // generateCollectionBlock creates an HCL block for a collection resource
 func generateCollectionBlock(c *client.Collection, resourceName string) *hclwrite.Block {
-	block := hclwrite.NewBlock("resource", []string{"typesense_collection", resourceName})
+	block := hclwrite.NewBlock("resource", []string{tfnames.FullTypeName(tfnames.ResourceCollection), resourceName})
 	body := block.Body()
 
 	body.SetAttributeValue("name", cty.StringVal(c.Name))
@@ -125,32 +132,33 @@ func generateCollectionBlock(c *client.Collection, resourceName string) *hclwrit
 			fieldBody.SetAttributeValue("symbols_to_index", cty.ListVal(sVals))
 		}
 		if field.Embed != nil {
-			embedBlock := fieldBody.AppendNewBlock("embed", nil)
-			embedBody := embedBlock.Body()
+			embedVals := make(map[string]cty.Value)
 			if len(field.Embed.From) > 0 {
 				fromVals := make([]cty.Value, len(field.Embed.From))
 				for i, v := range field.Embed.From {
 					fromVals[i] = cty.StringVal(v)
 				}
-				embedBody.SetAttributeValue("from", cty.ListVal(fromVals))
+				embedVals["from"] = cty.ListVal(fromVals)
 			}
-			mcBlock := embedBody.AppendNewBlock("model_config", nil)
-			mcBody := mcBlock.Body()
-			mcBody.SetAttributeValue("model_name", cty.StringVal(field.Embed.ModelConfig.ModelName))
+			modelConfigVals := map[string]cty.Value{
+				"model_name": cty.StringVal(field.Embed.ModelConfig.ModelName),
+			}
 			if field.Embed.ModelConfig.URL != "" {
-				mcBody.SetAttributeValue("url", cty.StringVal(field.Embed.ModelConfig.URL))
+				modelConfigVals["url"] = cty.StringVal(field.Embed.ModelConfig.URL)
 			}
 			// Intentionally omit api_key from generated HCL (sensitive)
+			embedVals["model_config"] = cty.ObjectVal(modelConfigVals)
+			fieldBody.SetAttributeValue("embed", cty.ObjectVal(embedVals))
 		}
 		if field.HnswParams != nil {
-			hpBlock := fieldBody.AppendNewBlock("hnsw_params", nil)
-			hpBody := hpBlock.Body()
+			hnswVals := make(map[string]cty.Value)
 			if field.HnswParams.EfConstruction > 0 {
-				hpBody.SetAttributeValue("ef_construction", cty.NumberIntVal(field.HnswParams.EfConstruction))
+				hnswVals["ef_construction"] = cty.NumberIntVal(field.HnswParams.EfConstruction)
 			}
 			if field.HnswParams.M > 0 {
-				hpBody.SetAttributeValue("m", cty.NumberIntVal(field.HnswParams.M))
+				hnswVals["m"] = cty.NumberIntVal(field.HnswParams.M)
 			}
+			fieldBody.SetAttributeValue("hnsw_params", cty.ObjectVal(hnswVals))
 		}
 	}
 
@@ -166,14 +174,14 @@ func generateCollectionBlock(c *client.Collection, resourceName string) *hclwrit
 
 // generateSynonymBlock creates an HCL block for a synonym resource
 func generateSynonymBlock(s *client.Synonym, collectionResourceName, resourceName string) *hclwrite.Block {
-	block := hclwrite.NewBlock("resource", []string{"typesense_synonym", resourceName})
+	block := hclwrite.NewBlock("resource", []string{tfnames.FullTypeName(tfnames.ResourceSynonym), resourceName})
 	body := block.Body()
 
 	// Reference the collection resource
 	body.AppendUnstructuredTokens(hclwrite.Tokens{
 		{Type: 9, Bytes: []byte("collection")}, // TokenIdent
-		{Type: 11, Bytes: []byte(" = ")},        // TokenEqual with spaces
-		{Type: 9, Bytes: []byte(fmt.Sprintf("typesense_collection.%s.name", collectionResourceName))},
+		{Type: 11, Bytes: []byte(" = ")},       // TokenEqual with spaces
+		{Type: 9, Bytes: []byte(fmt.Sprintf("%s.%s.name", tfnames.FullTypeName(tfnames.ResourceCollection), collectionResourceName))},
 		{Type: 10, Bytes: []byte("\n")}, // TokenNewline
 	})
 
@@ -196,35 +204,34 @@ func generateSynonymBlock(s *client.Synonym, collectionResourceName, resourceNam
 
 // generateOverrideBlock creates an HCL block for an override resource
 func generateOverrideBlock(o *client.Override, collectionResourceName, resourceName string) *hclwrite.Block {
-	block := hclwrite.NewBlock("resource", []string{"typesense_override", resourceName})
+	block := hclwrite.NewBlock("resource", []string{tfnames.FullTypeName(tfnames.ResourceOverride), resourceName})
 	body := block.Body()
 
 	// Reference the collection resource
 	body.AppendUnstructuredTokens(hclwrite.Tokens{
 		{Type: 9, Bytes: []byte("collection")},
 		{Type: 11, Bytes: []byte(" = ")},
-		{Type: 9, Bytes: []byte(fmt.Sprintf("typesense_collection.%s.name", collectionResourceName))},
+		{Type: 9, Bytes: []byte(fmt.Sprintf("%s.%s.name", tfnames.FullTypeName(tfnames.ResourceCollection), collectionResourceName))},
 		{Type: 10, Bytes: []byte("\n")},
 	})
 
 	body.SetAttributeValue("name", cty.StringVal(o.ID))
 
-	// Rule block
-	ruleBlock := body.AppendNewBlock("rule", nil)
-	ruleBody := ruleBlock.Body()
+	ruleVals := make(map[string]cty.Value)
 	if o.Rule.Query != "" {
-		ruleBody.SetAttributeValue("query", cty.StringVal(o.Rule.Query))
+		ruleVals["query"] = cty.StringVal(o.Rule.Query)
 	}
 	if o.Rule.Match != "" {
-		ruleBody.SetAttributeValue("match", cty.StringVal(o.Rule.Match))
+		ruleVals["match"] = cty.StringVal(o.Rule.Match)
 	}
 	if len(o.Rule.Tags) > 0 {
 		vals := make([]cty.Value, len(o.Rule.Tags))
 		for i, v := range o.Rule.Tags {
 			vals[i] = cty.StringVal(v)
 		}
-		ruleBody.SetAttributeValue("tags", cty.ListVal(vals))
+		ruleVals["tags"] = cty.ListVal(vals)
 	}
+	body.SetAttributeValue("rule", cty.ObjectVal(ruleVals))
 
 	// Includes
 	for _, inc := range o.Includes {
@@ -272,7 +279,7 @@ func generateOverrideBlock(o *client.Override, collectionResourceName, resourceN
 
 // generateStopwordsBlock creates an HCL block for a stopwords set resource
 func generateStopwordsBlock(sw *client.StopwordsSet, resourceName string) *hclwrite.Block {
-	block := hclwrite.NewBlock("resource", []string{"typesense_stopwords", resourceName})
+	block := hclwrite.NewBlock("resource", []string{tfnames.FullTypeName(tfnames.ResourceStopwordsSet), resourceName})
 	body := block.Body()
 
 	body.SetAttributeValue("name", cty.StringVal(sw.ID))
@@ -294,7 +301,7 @@ func generateStopwordsBlock(sw *client.StopwordsSet, resourceName string) *hclwr
 
 // generateClusterBlock creates an HCL block for a cloud cluster resource
 func generateClusterBlock(cl *client.Cluster, resourceName string) *hclwrite.Block {
-	block := hclwrite.NewBlock("resource", []string{"typesense_cluster", resourceName})
+	block := hclwrite.NewBlock("resource", []string{tfnames.FullTypeName(tfnames.ResourceCluster), resourceName})
 	body := block.Body()
 
 	body.SetAttributeValue("name", cty.StringVal(cl.Name))
@@ -325,7 +332,7 @@ func generateClusterBlock(cl *client.Cluster, resourceName string) *hclwrite.Blo
 
 // generateAnalyticsRuleBlock creates an HCL block for an analytics rule resource
 func generateAnalyticsRuleBlock(rule *client.AnalyticsRule, resourceName string) *hclwrite.Block {
-	block := hclwrite.NewBlock("resource", []string{"typesense_analytics_rule", resourceName})
+	block := hclwrite.NewBlock("resource", []string{tfnames.FullTypeName(tfnames.ResourceAnalyticsRule), resourceName})
 	body := block.Body()
 
 	body.SetAttributeValue("name", cty.StringVal(rule.Name))
@@ -352,7 +359,7 @@ func generateAnalyticsRuleBlock(rule *client.AnalyticsRule, resourceName string)
 
 // generateAPIKeyBlock creates an HCL block for an API key resource
 func generateAPIKeyBlock(key *client.APIKey, resourceName string) *hclwrite.Block {
-	block := hclwrite.NewBlock("resource", []string{"typesense_api_key", resourceName})
+	block := hclwrite.NewBlock("resource", []string{tfnames.FullTypeName(tfnames.ResourceAPIKey), resourceName})
 	body := block.Body()
 
 	// Add comment about non-recoverable key value
@@ -390,7 +397,7 @@ func generateAPIKeyBlock(key *client.APIKey, resourceName string) *hclwrite.Bloc
 
 // generateNLSearchModelBlock creates an HCL block for a NL search model resource
 func generateNLSearchModelBlock(model *client.NLSearchModel, resourceName string) *hclwrite.Block {
-	block := hclwrite.NewBlock("resource", []string{"typesense_nl_search_model", resourceName})
+	block := hclwrite.NewBlock("resource", []string{tfnames.FullTypeName(tfnames.ResourceNLSearchModel), resourceName})
 	body := block.Body()
 
 	body.SetAttributeValue("id", cty.StringVal(model.ID))
@@ -430,7 +437,7 @@ func generateNLSearchModelBlock(model *client.NLSearchModel, resourceName string
 
 // generateConversationModelBlock creates an HCL block for a conversation model resource
 func generateConversationModelBlock(model *client.ConversationModel, resourceName string) *hclwrite.Block {
-	block := hclwrite.NewBlock("resource", []string{"typesense_conversation_model", resourceName})
+	block := hclwrite.NewBlock("resource", []string{tfnames.FullTypeName(tfnames.ResourceConversationModel), resourceName})
 	body := block.Body()
 
 	if model.ID != "" {
@@ -469,4 +476,3 @@ func generateConversationModelBlock(model *client.ConversationModel, resourceNam
 
 	return block
 }
-

--- a/internal/generator/hcl_test.go
+++ b/internal/generator/hcl_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
@@ -22,6 +23,23 @@ func containsAttr(hcl, attrName, attrValue string) bool {
 	// Match attribute = value with flexible whitespace
 	pattern := regexp.MustCompile(regexp.QuoteMeta(attrName) + `\s*=\s*` + regexp.QuoteMeta(attrValue))
 	return pattern.MatchString(hcl)
+}
+
+func TestGenerateProviderBlockIncludesCredentialPlaceholders(t *testing.T) {
+	f := hclwrite.NewEmptyFile()
+
+	generateProviderBlock(f, "docs.a1.typesense.net", 443, "https", true, true)
+	hcl := string(f.Bytes())
+
+	if !containsAttr(hcl, "server_host", `"docs.a1.typesense.net"`) {
+		t.Error("Provider block should contain server_host")
+	}
+	if !strings.Contains(hcl, `# server_api_key = "YOUR_API_KEY_HERE"`) {
+		t.Error("Provider block should include server API key placeholder when server resources are exported")
+	}
+	if !strings.Contains(hcl, `# cloud_management_api_key = "YOUR_CLOUD_API_KEY_HERE"`) {
+		t.Error("Provider block should include cloud API key placeholder when cloud resources are exported")
+	}
 }
 
 func TestGenerateCollectionBlock(t *testing.T) {
@@ -57,7 +75,7 @@ func TestGenerateCollectionBlock(t *testing.T) {
 	hcl := blockToHCL(block)
 
 	// Check essential parts are present
-	if !strings.Contains(hcl, `resource "typesense_collection" "products"`) {
+	if !strings.Contains(hcl, `resource "`+tfnames.FullTypeName(tfnames.ResourceCollection)+`" "products"`) {
 		t.Error("Block should contain resource type and name")
 	}
 	if !containsAttr(hcl, "name", `"products"`) {
@@ -74,6 +92,49 @@ func TestGenerateCollectionBlock(t *testing.T) {
 	}
 }
 
+func TestGenerateCollectionBlockNestedAttributes(t *testing.T) {
+	collection := &client.Collection{
+		Name: "products",
+		Fields: []client.CollectionField{
+			{
+				Name:    "embedding",
+				Type:    "float[]",
+				NumDim:  384,
+				VecDist: "cosine",
+				Embed: &client.FieldEmbed{
+					From: []string{"title", "description"},
+					ModelConfig: client.FieldModelConfig{
+						ModelName: "ts/all-MiniLM-L12-v2",
+					},
+				},
+				HnswParams: &client.FieldHnswParams{
+					EfConstruction: 200,
+					M:              16,
+				},
+			},
+		},
+	}
+
+	block := generateCollectionBlock(collection, "products")
+	hcl := blockToHCL(block)
+
+	if !containsAttr(hcl, "embed", "{") {
+		t.Error("Block should emit embed as an object attribute")
+	}
+	if strings.Contains(hcl, "embed {") {
+		t.Error("Block should not emit embed as a nested block")
+	}
+	if !containsAttr(hcl, "model_config", "{") {
+		t.Error("Block should emit model_config as an object attribute")
+	}
+	if !containsAttr(hcl, "hnsw_params", "{") {
+		t.Error("Block should emit hnsw_params as an object attribute")
+	}
+	if strings.Contains(hcl, "hnsw_params {") {
+		t.Error("Block should not emit hnsw_params as a nested block")
+	}
+}
+
 func TestGenerateSynonymBlock(t *testing.T) {
 	synonym := &client.Synonym{
 		ID:       "clothing",
@@ -83,13 +144,13 @@ func TestGenerateSynonymBlock(t *testing.T) {
 	block := generateSynonymBlock(synonym, "products", "products_clothing")
 	hcl := blockToHCL(block)
 
-	if !strings.Contains(hcl, `resource "typesense_synonym" "products_clothing"`) {
+	if !strings.Contains(hcl, `resource "`+tfnames.FullTypeName(tfnames.ResourceSynonym)+`" "products_clothing"`) {
 		t.Error("Block should contain resource type and name")
 	}
 	if !containsAttr(hcl, "name", `"clothing"`) {
 		t.Error("Block should contain name attribute")
 	}
-	if !strings.Contains(hcl, "typesense_collection.products.name") {
+	if !strings.Contains(hcl, tfnames.FullTypeName(tfnames.ResourceCollection)+".products.name") {
 		t.Error("Block should reference collection")
 	}
 }
@@ -130,11 +191,14 @@ func TestGenerateOverrideBlock(t *testing.T) {
 	block := generateOverrideBlock(override, "products", "products_promote_sale")
 	hcl := blockToHCL(block)
 
-	if !strings.Contains(hcl, `resource "typesense_override" "products_promote_sale"`) {
+	if !strings.Contains(hcl, `resource "`+tfnames.FullTypeName(tfnames.ResourceOverride)+`" "products_promote_sale"`) {
 		t.Error("Block should contain resource type and name")
 	}
-	if !strings.Contains(hcl, "rule {") {
-		t.Error("Block should contain rule block")
+	if !containsAttr(hcl, "rule", "{") {
+		t.Error("Block should emit rule as an object attribute")
+	}
+	if strings.Contains(hcl, "rule {") {
+		t.Error("Block should not emit rule as a nested block")
 	}
 	if !containsAttr(hcl, "query", `"sale"`) {
 		t.Error("Block should contain query in rule")
@@ -160,7 +224,7 @@ func TestGenerateStopwordsBlock(t *testing.T) {
 	block := generateStopwordsBlock(stopwords, "common_words")
 	hcl := blockToHCL(block)
 
-	if !strings.Contains(hcl, `resource "typesense_stopwords" "common_words"`) {
+	if !strings.Contains(hcl, `resource "`+tfnames.FullTypeName(tfnames.ResourceStopwordsSet)+`" "common_words"`) {
 		t.Error("Block should contain resource type and name")
 	}
 	if !containsAttr(hcl, "name", `"common_words"`) {
@@ -186,7 +250,7 @@ func TestGenerateClusterBlock(t *testing.T) {
 	block := generateClusterBlock(cluster, "my_cluster")
 	hcl := blockToHCL(block)
 
-	if !strings.Contains(hcl, `resource "typesense_cluster" "my_cluster"`) {
+	if !strings.Contains(hcl, `resource "`+tfnames.FullTypeName(tfnames.ResourceCluster)+`" "my_cluster"`) {
 		t.Error("Block should contain resource type and name")
 	}
 	if !containsAttr(hcl, "name", `"my-cluster"`) {
@@ -215,7 +279,7 @@ func TestGenerateAnalyticsRuleBlock(t *testing.T) {
 	block := generateAnalyticsRuleBlock(rule, "popular_searches")
 	hcl := blockToHCL(block)
 
-	if !strings.Contains(hcl, `resource "typesense_analytics_rule" "popular_searches"`) {
+	if !strings.Contains(hcl, `resource "`+tfnames.FullTypeName(tfnames.ResourceAnalyticsRule)+`" "popular_searches"`) {
 		t.Error("Block should contain resource type and name")
 	}
 	if !containsAttr(hcl, "name", `"popular_searches"`) {
@@ -243,7 +307,7 @@ func TestGenerateAnalyticsRuleBlockCounter(t *testing.T) {
 		EventType:  "click",
 		Params: map[string]any{
 			"destination_collection": "product_clicks",
-			"counter_field":         "click_count",
+			"counter_field":          "click_count",
 		},
 	}
 
@@ -270,7 +334,7 @@ func TestGenerateAPIKeyBlock(t *testing.T) {
 	block := generateAPIKeyBlock(key, "search_only_key")
 	hcl := blockToHCL(block)
 
-	if !strings.Contains(hcl, `resource "typesense_api_key" "search_only_key"`) {
+	if !strings.Contains(hcl, `resource "`+tfnames.FullTypeName(tfnames.ResourceAPIKey)+`" "search_only_key"`) {
 		t.Error("Block should contain resource type and name")
 	}
 	if !strings.Contains(hcl, "API key value is not recoverable") {
@@ -321,7 +385,7 @@ func TestGenerateNLSearchModelBlock(t *testing.T) {
 	block := generateNLSearchModelBlock(model, "nl_model_1")
 	hcl := blockToHCL(block)
 
-	if !strings.Contains(hcl, `resource "typesense_nl_search_model" "nl_model_1"`) {
+	if !strings.Contains(hcl, `resource "`+tfnames.FullTypeName(tfnames.ResourceNLSearchModel)+`" "nl_model_1"`) {
 		t.Error("Block should contain resource type and name")
 	}
 	if !containsAttr(hcl, "id", `"nl_model_1"`) {
@@ -357,7 +421,7 @@ func TestGenerateConversationModelBlock(t *testing.T) {
 	block := generateConversationModelBlock(model, "conv_model_1")
 	hcl := blockToHCL(block)
 
-	if !strings.Contains(hcl, `resource "typesense_conversation_model" "conv_model_1"`) {
+	if !strings.Contains(hcl, `resource "`+tfnames.FullTypeName(tfnames.ResourceConversationModel)+`" "conv_model_1"`) {
 		t.Error("Block should contain resource type and name")
 	}
 	if !containsAttr(hcl, "id", `"conv_model_1"`) {

--- a/internal/generator/imports_test.go
+++ b/internal/generator/imports_test.go
@@ -3,17 +3,19 @@ package generator
 import (
 	"strings"
 	"testing"
+
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 )
 
 func TestGenerateImportScript(t *testing.T) {
 	commands := []ImportCommand{
 		{
-			ResourceType: "typesense_collection",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceCollection),
 			ResourceName: "products",
 			ImportID:     "products",
 		},
 		{
-			ResourceType: "typesense_synonym",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceSynonym),
 			ResourceName: "products_clothing",
 			ImportID:     "products/clothing",
 		},
@@ -30,10 +32,10 @@ func TestGenerateImportScript(t *testing.T) {
 	}
 
 	// Check import commands
-	if !strings.Contains(script, `terraform import typesense_collection.products "products"`) {
+	if !strings.Contains(script, `terraform import `+tfnames.FullTypeName(tfnames.ResourceCollection)+`.products "products"`) {
 		t.Error("Script should contain collection import command")
 	}
-	if !strings.Contains(script, `terraform import typesense_synonym.products_clothing "products/clothing"`) {
+	if !strings.Contains(script, `terraform import `+tfnames.FullTypeName(tfnames.ResourceSynonym)+`.products_clothing "products/clothing"`) {
 		t.Error("Script should contain synonym import command")
 	}
 }
@@ -104,22 +106,22 @@ func TestConversationModelImportID(t *testing.T) {
 func TestImportScriptWithNewResourceTypes(t *testing.T) {
 	commands := []ImportCommand{
 		{
-			ResourceType: "typesense_analytics_rule",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceAnalyticsRule),
 			ResourceName: "popular_searches",
 			ImportID:     "popular_searches",
 		},
 		{
-			ResourceType: "typesense_api_key",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceAPIKey),
 			ResourceName: "search_only_key",
 			ImportID:     "1",
 		},
 		{
-			ResourceType: "typesense_nl_search_model",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceNLSearchModel),
 			ResourceName: "nl_model_1",
 			ImportID:     "nl_model_1",
 		},
 		{
-			ResourceType: "typesense_conversation_model",
+			ResourceType: tfnames.FullTypeName(tfnames.ResourceConversationModel),
 			ResourceName: "conv_model_1",
 			ImportID:     "conv_model_1",
 		},
@@ -127,16 +129,16 @@ func TestImportScriptWithNewResourceTypes(t *testing.T) {
 
 	script := GenerateImportScript(commands)
 
-	if !strings.Contains(script, `terraform import typesense_analytics_rule.popular_searches "popular_searches"`) {
+	if !strings.Contains(script, `terraform import `+tfnames.FullTypeName(tfnames.ResourceAnalyticsRule)+`.popular_searches "popular_searches"`) {
 		t.Error("Script should contain analytics rule import command")
 	}
-	if !strings.Contains(script, `terraform import typesense_api_key.search_only_key "1"`) {
+	if !strings.Contains(script, `terraform import `+tfnames.FullTypeName(tfnames.ResourceAPIKey)+`.search_only_key "1"`) {
 		t.Error("Script should contain API key import command")
 	}
-	if !strings.Contains(script, `terraform import typesense_nl_search_model.nl_model_1 "nl_model_1"`) {
+	if !strings.Contains(script, `terraform import `+tfnames.FullTypeName(tfnames.ResourceNLSearchModel)+`.nl_model_1 "nl_model_1"`) {
 		t.Error("Script should contain NL search model import command")
 	}
-	if !strings.Contains(script, `terraform import typesense_conversation_model.conv_model_1 "conv_model_1"`) {
+	if !strings.Contains(script, `terraform import `+tfnames.FullTypeName(tfnames.ResourceConversationModel)+`.conv_model_1 "conv_model_1"`) {
 		t.Error("Script should contain conversation model import command")
 	}
 }

--- a/internal/generator/terraform_validate_test.go
+++ b/internal/generator/terraform_validate_test.go
@@ -1,0 +1,328 @@
+package generator
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+func repoRootForTerraformValidate(t *testing.T) string {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to determine test file path")
+	}
+
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+}
+
+func providerBinaryNameForTerraformValidate() string {
+	if runtime.GOOS == "windows" {
+		return "terraform-provider-typesense.exe"
+	}
+
+	return "terraform-provider-typesense"
+}
+
+func buildProviderBinaryForTerraformValidate(t *testing.T, repoRoot string) string {
+	t.Helper()
+
+	buildDir := t.TempDir()
+	binaryPath := filepath.Join(buildDir, providerBinaryNameForTerraformValidate())
+
+	cmd := exec.Command("go", "build", "-o", binaryPath, ".")
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build provider binary: %v\n%s", err, string(output))
+	}
+
+	return buildDir
+}
+
+func TestGenerateStopwordsUsesStopwordsSetResourceType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/stopwords" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if got := r.Header.Get("X-TYPESENSE-API-KEY"); got != "test-key" {
+			t.Fatalf("unexpected API key header: %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"stopwords":[{"id":"english","stopwords":["the","a"],"locale":"en"}]}`))
+	}))
+	defer server.Close()
+
+	serverURL := strings.TrimPrefix(server.URL, "http://")
+	host, portStr, err := net.SplitHostPort(serverURL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("failed to parse test server port: %v", err)
+	}
+
+	g := New(&Config{
+		Host:     host,
+		Port:     port,
+		Protocol: "http",
+		APIKey:   "test-key",
+	})
+
+	f := hclwrite.NewEmptyFile()
+	resourceNames := make(map[string]bool)
+	var importCommands []ImportCommand
+
+	if err := g.generateStopwords(context.Background(), f, resourceNames, &importCommands); err != nil {
+		t.Fatalf("generateStopwords() returned error: %v", err)
+	}
+
+	hcl := string(f.Bytes())
+	if !strings.Contains(hcl, `resource "`+tfnames.FullTypeName(tfnames.ResourceStopwordsSet)+`" "english"`) {
+		t.Fatalf("generated HCL did not contain stopwords_set resource:\n%s", hcl)
+	}
+
+	if len(importCommands) != 1 {
+		t.Fatalf("generateStopwords() produced %d import commands, want 1", len(importCommands))
+	}
+	if importCommands[0].ResourceType != tfnames.FullTypeName(tfnames.ResourceStopwordsSet) {
+		t.Fatalf("generateStopwords() import resource type = %q, want %q", importCommands[0].ResourceType, tfnames.FullTypeName(tfnames.ResourceStopwordsSet))
+	}
+}
+
+func TestGeneratedHCLValidatesWithTerraform(t *testing.T) {
+	terraformPath, err := exec.LookPath("terraform")
+	if err != nil {
+		t.Skip("terraform binary not found in PATH")
+	}
+
+	root := repoRootForTerraformValidate(t)
+	providerDir := buildProviderBinaryForTerraformValidate(t, root)
+
+	baseCollection := &client.Collection{
+		Name: "products",
+		Fields: []client.CollectionField{
+			{
+				Name: "id",
+				Type: "string",
+			},
+			{
+				Name:    "embedding",
+				Type:    "float[]",
+				NumDim:  384,
+				VecDist: "cosine",
+				Embed: &client.FieldEmbed{
+					From: []string{"title", "description"},
+					ModelConfig: client.FieldModelConfig{
+						ModelName: "ts/all-MiniLM-L12-v2",
+					},
+				},
+				HnswParams: &client.FieldHnswParams{
+					EfConstruction: 200,
+					M:              16,
+				},
+			},
+		},
+	}
+
+	type terraformValidateCase struct {
+		name         string
+		resourceName string
+		appendBlocks func(body *hclwrite.Body)
+	}
+
+	cases := []terraformValidateCase{
+		{
+			name:         "cluster",
+			resourceName: tfnames.ResourceCluster,
+			appendBlocks: func(body *hclwrite.Body) {
+				body.AppendBlock(generateClusterBlock(&client.Cluster{
+					Name:                   "smoke-cluster",
+					Memory:                 "2_gb",
+					VCPU:                   "2_vcpus_4_hr_burst_per_day",
+					TypesenseServerVersion: "30.2",
+					Regions:                []string{"hyderabad"},
+				}, "smoke_cluster"))
+				body.AppendNewline()
+			},
+		},
+		{
+			name:         "collection",
+			resourceName: tfnames.ResourceCollection,
+			appendBlocks: func(body *hclwrite.Body) {
+				body.AppendBlock(generateCollectionBlock(baseCollection, "products"))
+				body.AppendNewline()
+			},
+		},
+		{
+			name:         "stopwords",
+			resourceName: tfnames.ResourceStopwordsSet,
+			appendBlocks: func(body *hclwrite.Body) {
+				body.AppendBlock(generateStopwordsBlock(&client.StopwordsSet{
+					ID:        "english",
+					Stopwords: []string{"the", "a", "an"},
+					Locale:    "en",
+				}, "english"))
+				body.AppendNewline()
+			},
+		},
+		{
+			name:         "synonym",
+			resourceName: tfnames.ResourceSynonym,
+			appendBlocks: func(body *hclwrite.Body) {
+				body.AppendBlock(generateCollectionBlock(baseCollection, "products"))
+				body.AppendNewline()
+				body.AppendBlock(generateSynonymBlock(&client.Synonym{
+					ID:       "shoe_terms",
+					Synonyms: []string{"shoe", "sneaker"},
+				}, "products", "shoe_terms"))
+				body.AppendNewline()
+			},
+		},
+		{
+			name:         "override",
+			resourceName: tfnames.ResourceOverride,
+			appendBlocks: func(body *hclwrite.Body) {
+				body.AppendBlock(generateCollectionBlock(baseCollection, "products"))
+				body.AppendNewline()
+				body.AppendBlock(generateOverrideBlock(&client.Override{
+					ID: "featured",
+					Rule: client.OverrideRule{
+						Query: "featured",
+						Match: "exact",
+					},
+				}, "products", "featured"))
+				body.AppendNewline()
+			},
+		},
+		{
+			name:         "analytics_rule",
+			resourceName: tfnames.ResourceAnalyticsRule,
+			appendBlocks: func(body *hclwrite.Body) {
+				body.AppendBlock(generateAnalyticsRuleBlock(&client.AnalyticsRule{
+					Name:       "popular_searches",
+					Type:       "popular_queries",
+					Collection: "products",
+					EventType:  "search",
+					Params: map[string]any{
+						"destination_collection": "product_queries",
+						"limit":                  float64(1000),
+					},
+				}, "popular_searches"))
+				body.AppendNewline()
+			},
+		},
+		{
+			name:         "api_key",
+			resourceName: tfnames.ResourceAPIKey,
+			appendBlocks: func(body *hclwrite.Body) {
+				body.AppendBlock(generateAPIKeyBlock(&client.APIKey{
+					Description: "search-only",
+					Actions:     []string{"documents:search"},
+					Collections: []string{"products"},
+				}, "search_only"))
+				body.AppendNewline()
+			},
+		},
+		{
+			name:         "nl_search_model",
+			resourceName: tfnames.ResourceNLSearchModel,
+			appendBlocks: func(body *hclwrite.Body) {
+				body.AppendBlock(generateNLSearchModelBlock(&client.NLSearchModel{
+					ID:        "nl-model",
+					ModelName: "openai/gpt-4o-mini",
+				}, "nl_model"))
+				body.AppendNewline()
+			},
+		},
+		{
+			name:         "conversation_model",
+			resourceName: tfnames.ResourceConversationModel,
+			appendBlocks: func(body *hclwrite.Body) {
+				body.AppendBlock(generateConversationModelBlock(&client.ConversationModel{
+					ID:                "conversation-model",
+					ModelName:         "openai/gpt-4o-mini",
+					HistoryCollection: "conversation_history",
+					SystemPrompt:      "Answer based on indexed content.",
+				}, "conversation_model"))
+				body.AppendNewline()
+			},
+		},
+	}
+
+	coveredResourceNames := make(map[string]bool, len(cases))
+	for _, tc := range cases {
+		coveredResourceNames[tc.resourceName] = true
+	}
+	if len(coveredResourceNames) != len(tfnames.GeneratedResourceNames) {
+		t.Fatalf("terraform validate cases cover %d generated resource names, want %d", len(coveredResourceNames), len(tfnames.GeneratedResourceNames))
+	}
+	for _, resourceName := range tfnames.GeneratedResourceNames {
+		if !coveredResourceNames[resourceName] {
+			t.Fatalf("missing terraform validate case for generated resource %q", resourceName)
+		}
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tfDir := t.TempDir()
+			cliConfigPath := filepath.Join(tfDir, "terraform.rc")
+			cliConfig := fmt.Sprintf(`provider_installation {
+  dev_overrides {
+    %q = %q
+  }
+  direct {}
+}
+`, tfnames.ProviderSource, filepath.ToSlash(providerDir))
+			if err := os.WriteFile(cliConfigPath, []byte(cliConfig), 0644); err != nil {
+				t.Fatalf("failed to write terraform CLI config: %v", err)
+			}
+
+			f := hclwrite.NewEmptyFile()
+			generateTerraformBlock(f)
+			generateProviderBlock(f, "example.a1.typesense.net", 443, "https", true, true)
+			tc.appendBlocks(f.Body())
+
+			mainTFPath := filepath.Join(tfDir, "main.tf")
+			if err := os.WriteFile(mainTFPath, f.Bytes(), 0644); err != nil {
+				t.Fatalf("failed to write generated Terraform config: %v", err)
+			}
+
+			variablesTFPath := filepath.Join(tfDir, "variables.tf")
+			if err := os.WriteFile(variablesTFPath, []byte("variable \"openai_api_key\" {\n  type = string\n}\n"), 0644); err != nil {
+				t.Fatalf("failed to write Terraform variables file: %v", err)
+			}
+
+			cmd := exec.Command(terraformPath, "validate")
+			cmd.Dir = tfDir
+			cmd.Env = append(os.Environ(),
+				"TF_CLI_CONFIG_FILE="+cliConfigPath,
+				"TF_IN_AUTOMATION=1",
+				"CHECKPOINT_DISABLE=1",
+			)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("terraform validate failed: %v\n%s", err, string(output))
+			}
+		})
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alanm/terraform-provider-typesense/internal/client"
 	"github.com/alanm/terraform-provider-typesense/internal/datasources"
 	"github.com/alanm/terraform-provider-typesense/internal/resources"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/alanm/terraform-provider-typesense/internal/version"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -46,7 +47,7 @@ type TypesenseProviderModel struct {
 type ProviderData = providertypes.ProviderData
 
 func (p *TypesenseProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
-	resp.TypeName = "typesense"
+	resp.TypeName = tfnames.ProviderTypeName
 	resp.Version = p.version
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,10 +1,16 @@
 package provider
 
 import (
+	"context"
 	"os"
+	"sort"
 	"testing"
 
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	frameworkprovider "github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
@@ -28,5 +34,79 @@ func testAccPreCheck(t *testing.T) {
 	}
 	if v := os.Getenv("TYPESENSE_API_KEY"); v == "" {
 		t.Fatal("TYPESENSE_API_KEY must be set for acceptance tests")
+	}
+}
+
+func metadataNamesFromResources(t *testing.T, resources []func() resource.Resource) []string {
+	t.Helper()
+
+	names := make([]string, 0, len(resources))
+	for _, factory := range resources {
+		r := factory()
+		var resp resource.MetadataResponse
+		r.Metadata(context.Background(), resource.MetadataRequest{
+			ProviderTypeName: tfnames.ProviderTypeName,
+		}, &resp)
+		names = append(names, resp.TypeName)
+	}
+
+	sort.Strings(names)
+	return names
+}
+
+func metadataNamesFromDataSources(t *testing.T, dataSources []func() datasource.DataSource) []string {
+	t.Helper()
+
+	names := make([]string, 0, len(dataSources))
+	for _, factory := range dataSources {
+		d := factory()
+		var resp datasource.MetadataResponse
+		d.Metadata(context.Background(), datasource.MetadataRequest{
+			ProviderTypeName: tfnames.ProviderTypeName,
+		}, &resp)
+		names = append(names, resp.TypeName)
+	}
+
+	sort.Strings(names)
+	return names
+}
+
+func TestRegisteredResourceAndDataSourceTypeNamesMatchSharedRegistry(t *testing.T) {
+	p := New("test")().(*TypesenseProvider)
+
+	var providerMeta frameworkprovider.MetadataResponse
+	p.Metadata(context.Background(), frameworkprovider.MetadataRequest{}, &providerMeta)
+	if providerMeta.TypeName != tfnames.ProviderTypeName {
+		t.Fatalf("provider type name = %q, want %q", providerMeta.TypeName, tfnames.ProviderTypeName)
+	}
+
+	resourceNames := metadataNamesFromResources(t, p.Resources(context.Background()))
+	expectedResourceNames := make([]string, 0, len(tfnames.ResourceNames))
+	for _, name := range tfnames.ResourceNames {
+		expectedResourceNames = append(expectedResourceNames, tfnames.FullTypeName(name))
+	}
+	sort.Strings(expectedResourceNames)
+	if len(resourceNames) != len(expectedResourceNames) {
+		t.Fatalf("registered %d resource types, shared registry has %d", len(resourceNames), len(expectedResourceNames))
+	}
+	for i := range resourceNames {
+		if resourceNames[i] != expectedResourceNames[i] {
+			t.Fatalf("resource type mismatch at index %d: got %q want %q", i, resourceNames[i], expectedResourceNames[i])
+		}
+	}
+
+	dataSourceNames := metadataNamesFromDataSources(t, p.DataSources(context.Background()))
+	expectedDataSourceNames := make([]string, 0, len(tfnames.DataSourceNames))
+	for _, name := range tfnames.DataSourceNames {
+		expectedDataSourceNames = append(expectedDataSourceNames, tfnames.FullTypeName(name))
+	}
+	sort.Strings(expectedDataSourceNames)
+	if len(dataSourceNames) != len(expectedDataSourceNames) {
+		t.Fatalf("registered %d data source types, shared registry has %d", len(dataSourceNames), len(expectedDataSourceNames))
+	}
+	for i := range dataSourceNames {
+		if dataSourceNames[i] != expectedDataSourceNames[i] {
+			t.Fatalf("data source type mismatch at index %d: got %q want %q", i, dataSourceNames[i], expectedDataSourceNames[i])
+		}
 	}
 }

--- a/internal/resources/analytics_rule.go
+++ b/internal/resources/analytics_rule.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/alanm/terraform-provider-typesense/internal/version"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -41,7 +42,7 @@ type AnalyticsRuleResourceModel struct {
 }
 
 func (r *AnalyticsRuleResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_analytics_rule"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.ResourceAnalyticsRule)
 }
 
 func (r *AnalyticsRuleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -113,7 +114,7 @@ func (r *AnalyticsRuleResource) Configure(ctx context.Context, req resource.Conf
 }
 
 func (r *AnalyticsRuleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	if diags := version.CheckVersionRequirement(r.featureChecker, version.FeatureAnalyticsRules, "typesense_analytics_rule"); diags.HasError() {
+	if diags := version.CheckVersionRequirement(r.featureChecker, version.FeatureAnalyticsRules, tfnames.FullTypeName(tfnames.ResourceAnalyticsRule)); diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}

--- a/internal/resources/api_key.go
+++ b/internal/resources/api_key.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -42,7 +43,7 @@ type APIKeyResourceModel struct {
 }
 
 func (r *APIKeyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_api_key"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.ResourceAPIKey)
 }
 
 func (r *APIKeyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -52,7 +53,7 @@ type ClusterResourceModel struct {
 }
 
 func (r *ClusterResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_cluster"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.ResourceCluster)
 }
 
 func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/resources/cluster_config.go
+++ b/internal/resources/cluster_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -40,7 +41,7 @@ type ClusterConfigChangeResourceModel struct {
 }
 
 func (r *ClusterConfigChangeResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_cluster_config_change"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.ResourceClusterConfigChange)
 }
 
 func (r *ClusterConfigChangeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/resources/collection.go
+++ b/internal/resources/collection.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -115,7 +116,7 @@ func fieldAttrTypes() map[string]attr.Type {
 }
 
 func (r *CollectionResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_collection"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.ResourceCollection)
 }
 
 func (r *CollectionResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/resources/collection_alias.go
+++ b/internal/resources/collection_alias.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -35,7 +36,7 @@ type CollectionAliasResourceModel struct {
 }
 
 func (r *CollectionAliasResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_collection_alias"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.ResourceCollectionAlias)
 }
 
 func (r *CollectionAliasResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/resources/conversation_model.go
+++ b/internal/resources/conversation_model.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/alanm/terraform-provider-typesense/internal/version"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -44,7 +45,7 @@ type ConversationModelResourceModel struct {
 }
 
 func (r *ConversationModelResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_conversation_model"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.ResourceConversationModel)
 }
 
 func (r *ConversationModelResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -132,7 +133,7 @@ func (r *ConversationModelResource) Configure(ctx context.Context, req resource.
 }
 
 func (r *ConversationModelResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	if diags := version.CheckVersionRequirement(r.featureChecker, version.FeatureConversationModels, "typesense_conversation_model"); diags.HasError() {
+	if diags := version.CheckVersionRequirement(r.featureChecker, version.FeatureConversationModels, tfnames.FullTypeName(tfnames.ResourceConversationModel)); diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}

--- a/internal/resources/nl_search_model.go
+++ b/internal/resources/nl_search_model.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/alanm/terraform-provider-typesense/internal/version"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -56,7 +57,7 @@ type NLSearchModelResourceModel struct {
 }
 
 func (r *NLSearchModelResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_nl_search_model"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.ResourceNLSearchModel)
 }
 
 func (r *NLSearchModelResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -185,7 +186,7 @@ func (r *NLSearchModelResource) Configure(ctx context.Context, req resource.Conf
 }
 
 func (r *NLSearchModelResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	if diags := version.CheckVersionRequirement(r.featureChecker, version.FeatureNLSearchModels, "typesense_nl_search_model"); diags.HasError() {
+	if diags := version.CheckVersionRequirement(r.featureChecker, version.FeatureNLSearchModels, tfnames.FullTypeName(tfnames.ResourceNLSearchModel)); diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}

--- a/internal/resources/override.go
+++ b/internal/resources/override.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/alanm/terraform-provider-typesense/internal/version"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -71,7 +72,7 @@ type OverrideExcludeModel struct {
 }
 
 func (r *OverrideResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_override"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.ResourceOverride)
 }
 
 func (r *OverrideResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/resources/preset.go
+++ b/internal/resources/preset.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/alanm/terraform-provider-typesense/internal/version"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -38,7 +39,7 @@ type PresetResourceModel struct {
 }
 
 func (r *PresetResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_preset"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.ResourcePreset)
 }
 
 func (r *PresetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -95,7 +96,7 @@ func (r *PresetResource) Configure(ctx context.Context, req resource.ConfigureRe
 }
 
 func (r *PresetResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	if diags := version.CheckVersionRequirement(r.featureChecker, version.FeaturePresets, "typesense_preset"); diags.HasError() {
+	if diags := version.CheckVersionRequirement(r.featureChecker, version.FeaturePresets, tfnames.FullTypeName(tfnames.ResourcePreset)); diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}

--- a/internal/resources/stemming_dictionary.go
+++ b/internal/resources/stemming_dictionary.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -43,7 +44,7 @@ var wordStemMappingAttrTypes = map[string]attr.Type{
 }
 
 func (r *StemmingDictionaryResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_stemming_dictionary"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.ResourceStemmingDictionary)
 }
 
 func (r *StemmingDictionaryResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/resources/stopwords.go
+++ b/internal/resources/stopwords.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/alanm/terraform-provider-typesense/internal/version"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -38,7 +39,7 @@ type StopwordsSetResourceModel struct {
 }
 
 func (r *StopwordsSetResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_stopwords_set"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.ResourceStopwordsSet)
 }
 
 func (r *StopwordsSetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -100,7 +101,7 @@ func (r *StopwordsSetResource) Configure(ctx context.Context, req resource.Confi
 }
 
 func (r *StopwordsSetResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	if diags := version.CheckVersionRequirement(r.featureChecker, version.FeatureStopwords, "typesense_stopwords_set"); diags.HasError() {
+	if diags := version.CheckVersionRequirement(r.featureChecker, version.FeatureStopwords, tfnames.FullTypeName(tfnames.ResourceStopwordsSet)); diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}

--- a/internal/resources/synonym.go
+++ b/internal/resources/synonym.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/alanm/terraform-provider-typesense/internal/client"
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 	providertypes "github.com/alanm/terraform-provider-typesense/internal/types"
 	"github.com/alanm/terraform-provider-typesense/internal/version"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -45,7 +46,7 @@ type SynonymResourceModel struct {
 }
 
 func (r *SynonymResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_synonym"
+	resp.TypeName = tfnames.TypeName(req.ProviderTypeName, tfnames.ResourceSynonym)
 }
 
 func (r *SynonymResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/tfnames/tfnames.go
+++ b/internal/tfnames/tfnames.go
@@ -1,0 +1,68 @@
+package tfnames
+
+const ProviderTypeName = "typesense"
+const ProviderSource = "alanm/typesense"
+
+const (
+	ResourceCluster             = "cluster"
+	ResourceClusterConfigChange = "cluster_config_change"
+	ResourceCollection          = "collection"
+	ResourceCollectionAlias     = "collection_alias"
+	ResourceSynonym             = "synonym"
+	ResourceOverride            = "override"
+	ResourceStopwordsSet        = "stopwords_set"
+	ResourcePreset              = "preset"
+	ResourceAnalyticsRule       = "analytics_rule"
+	ResourceAPIKey              = "api_key"
+	ResourceNLSearchModel       = "nl_search_model"
+	ResourceConversationModel   = "conversation_model"
+	ResourceStemmingDictionary  = "stemming_dictionary"
+)
+
+const (
+	DataSourceCollections = "collections"
+	DataSourceAPIKeys     = "api_keys"
+	DataSourceServerInfo  = "server_info"
+)
+
+var ResourceNames = []string{
+	ResourceCluster,
+	ResourceClusterConfigChange,
+	ResourceCollection,
+	ResourceCollectionAlias,
+	ResourceSynonym,
+	ResourceOverride,
+	ResourceStopwordsSet,
+	ResourcePreset,
+	ResourceAnalyticsRule,
+	ResourceAPIKey,
+	ResourceNLSearchModel,
+	ResourceConversationModel,
+	ResourceStemmingDictionary,
+}
+
+var GeneratedResourceNames = []string{
+	ResourceCluster,
+	ResourceCollection,
+	ResourceStopwordsSet,
+	ResourceSynonym,
+	ResourceOverride,
+	ResourceAnalyticsRule,
+	ResourceAPIKey,
+	ResourceNLSearchModel,
+	ResourceConversationModel,
+}
+
+var DataSourceNames = []string{
+	DataSourceCollections,
+	DataSourceAPIKeys,
+	DataSourceServerInfo,
+}
+
+func TypeName(providerTypeName, name string) string {
+	return providerTypeName + "_" + name
+}
+
+func FullTypeName(name string) string {
+	return TypeName(ProviderTypeName, name)
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -3,17 +3,19 @@ package version
 import (
 	"strings"
 	"testing"
+
+	"github.com/alanm/terraform-provider-typesense/internal/tfnames"
 )
 
 func TestParse(t *testing.T) {
 	tests := []struct {
-		name       string
-		input      string
-		wantMajor  int
-		wantMinor  int
-		wantPatch  int
-		wantPre    string
-		wantErr    bool
+		name      string
+		input     string
+		wantMajor int
+		wantMinor int
+		wantPatch int
+		wantPre   string
+		wantErr   bool
 	}{
 		{
 			name:      "simple two-part version",
@@ -406,7 +408,7 @@ func TestWellKnownVersions(t *testing.T) {
 func TestCheckVersionRequirement(t *testing.T) {
 	t.Run("returns error when version is too old", func(t *testing.T) {
 		checker := NewFeatureChecker(MustParse("26.0"))
-		diags := CheckVersionRequirement(checker, FeaturePresets, "typesense_preset")
+		diags := CheckVersionRequirement(checker, FeaturePresets, tfnames.FullTypeName(tfnames.ResourcePreset))
 		if !diags.HasError() {
 			t.Fatal("expected error diagnostic, got none")
 		}
@@ -417,14 +419,14 @@ func TestCheckVersionRequirement(t *testing.T) {
 		if !strings.Contains(errMsg, "v26.0") {
 			t.Errorf("error should mention current server version v26.0, got: %s", errMsg)
 		}
-		if !strings.Contains(errMsg, "typesense_preset") {
+		if !strings.Contains(errMsg, tfnames.FullTypeName(tfnames.ResourcePreset)) {
 			t.Errorf("error should mention resource name, got: %s", errMsg)
 		}
 	})
 
 	t.Run("returns nil when version meets requirement", func(t *testing.T) {
 		checker := NewFeatureChecker(MustParse("27.0"))
-		diags := CheckVersionRequirement(checker, FeaturePresets, "typesense_preset")
+		diags := CheckVersionRequirement(checker, FeaturePresets, tfnames.FullTypeName(tfnames.ResourcePreset))
 		if diags.HasError() {
 			t.Errorf("expected no error, got: %v", diags)
 		}
@@ -432,7 +434,7 @@ func TestCheckVersionRequirement(t *testing.T) {
 
 	t.Run("returns nil when version exceeds requirement", func(t *testing.T) {
 		checker := NewFeatureChecker(MustParse("30.0"))
-		diags := CheckVersionRequirement(checker, FeaturePresets, "typesense_preset")
+		diags := CheckVersionRequirement(checker, FeaturePresets, tfnames.FullTypeName(tfnames.ResourcePreset))
 		if diags.HasError() {
 			t.Errorf("expected no error, got: %v", diags)
 		}
@@ -440,7 +442,7 @@ func TestCheckVersionRequirement(t *testing.T) {
 
 	t.Run("skips check when version is unknown (fallback)", func(t *testing.T) {
 		checker := NewFallbackFeatureChecker()
-		diags := CheckVersionRequirement(checker, FeaturePresets, "typesense_preset")
+		diags := CheckVersionRequirement(checker, FeaturePresets, tfnames.FullTypeName(tfnames.ResourcePreset))
 		if diags != nil {
 			t.Errorf("expected nil diagnostics for fallback checker, got: %v", diags)
 		}
@@ -448,7 +450,7 @@ func TestCheckVersionRequirement(t *testing.T) {
 
 	t.Run("skips check when version is nil", func(t *testing.T) {
 		checker := NewFeatureChecker(nil)
-		diags := CheckVersionRequirement(checker, FeaturePresets, "typesense_preset")
+		diags := CheckVersionRequirement(checker, FeaturePresets, tfnames.FullTypeName(tfnames.ResourcePreset))
 		if diags != nil {
 			t.Errorf("expected nil diagnostics for nil version, got: %v", diags)
 		}
@@ -456,17 +458,17 @@ func TestCheckVersionRequirement(t *testing.T) {
 
 	t.Run("error message for each feature type", func(t *testing.T) {
 		featureTests := []struct {
-			feature      Feature
-			resource     string
-			tooOld       string
-			wantVersion  string
+			feature     Feature
+			resource    string
+			tooOld      string
+			wantVersion string
 		}{
-			{FeatureConversationModels, "typesense_conversation_model", "25.0", "v26.0+"},
-			{FeaturePresets, "typesense_preset", "26.0", "v27.0+"},
-			{FeatureStopwords, "typesense_stopwords_set", "26.0", "v27.0+"},
-			{FeatureAnalyticsRules, "typesense_analytics_rule", "27.0", "v28.0+"},
-			{FeatureNLSearchModels, "typesense_nl_search_model", "28.0", "v29.0+"},
-			{FeatureStemmingDictionaries, "typesense_stemming_dictionary", "28.0", "v29.0+"},
+			{FeatureConversationModels, tfnames.FullTypeName(tfnames.ResourceConversationModel), "25.0", "v26.0+"},
+			{FeaturePresets, tfnames.FullTypeName(tfnames.ResourcePreset), "26.0", "v27.0+"},
+			{FeatureStopwords, tfnames.FullTypeName(tfnames.ResourceStopwordsSet), "26.0", "v27.0+"},
+			{FeatureAnalyticsRules, tfnames.FullTypeName(tfnames.ResourceAnalyticsRule), "27.0", "v28.0+"},
+			{FeatureNLSearchModels, tfnames.FullTypeName(tfnames.ResourceNLSearchModel), "28.0", "v29.0+"},
+			{FeatureStemmingDictionaries, tfnames.FullTypeName(tfnames.ResourceStemmingDictionary), "28.0", "v29.0+"},
 		}
 
 		for _, tt := range featureTests {

--- a/testbed/scripts/run-e2e-test.sh
+++ b/testbed/scripts/run-e2e-test.sh
@@ -20,6 +20,7 @@ EXPORT_DIR="${EXPORT_DIR:-$TESTBED_DIR/export}"
 
 # Cleanup on exit
 CLEANUP_ON_EXIT="${CLEANUP_ON_EXIT:-false}"
+FAIL_ON_PLAN_CHANGES="${FAIL_ON_PLAN_CHANGES:-false}"
 
 log() {
     echo ""
@@ -224,12 +225,17 @@ EOF
     plan_output=$(terraform plan -detailed-exitcode 2>&1) || {
         local exit_code=$?
         if [ $exit_code -eq 2 ]; then
+            if [ "$FAIL_ON_PLAN_CHANGES" = "true" ]; then
+                echo "ERROR: Terraform plan shows changes:"
+                echo "$plan_output"
+                exit 1
+            fi
             echo "WARNING: Terraform plan shows changes:"
             echo "$plan_output"
-            # Not failing the test for now, as this may be expected
         elif [ $exit_code -ne 0 ]; then
             echo "Terraform plan failed:"
             echo "$plan_output"
+            exit $exit_code
         fi
     }
 


### PR DESCRIPTION
## Summary
- centralize Terraform provider, resource, and data source type names in a shared registry and verify provider registration matches it
- align generated HCL with the provider schema and add Terraform validate smoke coverage for every generator-emitted resource type
- add a nightly seeded generate/import/plan workflow and fail the E2E script when plan drift is detected

## Testing
- go test ./...
- go test ./internal/generator -run TestGeneratedHCLValidatesWithTerraform -v
- bash -n testbed/scripts/run-e2e-test.sh